### PR TITLE
allow cookies, newer user-agent, update lxml version

### DIFF
--- a/price-alert.py
+++ b/price-alert.py
@@ -37,10 +37,10 @@ def send_email(price, url, email_info):
 
 
 def get_price(url, selector):
-    r = requests.get(url, headers={
+    r = requests.Session().get(url, headers={
         'User-Agent':
             'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
-            '(KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36'
+            '(KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36'
     })
     r.raise_for_status()
     tree = html.fromstring(r.text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.20.0
-lxml==3.5.0
+lxml==4.3.0


### PR DESCRIPTION
Hey there,

I just came across your awesome script and wanted to use it for myself.

I experienced some issues while setting it up, so I fixed them.

First, I couldn't install `lxml==3.5.0` in a `python -m venv`, so I just tried with the newest version and it seemed to work.

Also, Amazon responded with a captcha, telling me that automated scraping isn't cool. But they dropped a hint that they missed being able to set cookies, so I just used a `requests.Session` instead of a simple `get()`. That solved the problem and now I can get alerts!

Oh, and while I was at it, I updated the user-agent, too. Just in case. :)